### PR TITLE
add another solution for issue: #2

### DIFF
--- a/meta_pdf/MITL
+++ b/meta_pdf/MITL
@@ -1,0 +1,20 @@
+Copyright (c) 2019 Masayoshi Takahashi
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+

--- a/meta_pdf/meta_pdf.rb
+++ b/meta_pdf/meta_pdf.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+
+require 'tmpdir'
+
+PDFTK_CMD = ENV["PDFTK_CMD"] || "pdftk"
+
+def usage
+  puts "usage: meta_pdf.rb <input.pdf> <output.pdf>"
+  exit
+end
+
+def update_meta(input_file, output_file, title:, subject:)
+  Dir.mktmpdir do |dir|
+    meta_file = File.join(dir, "meta.txt")
+    File.open(meta_file, "w") do |f|
+      f.write <<-EOB
+InfoBegin
+InfoKey: Title
+InfoValue: #{title}
+InfoBegin
+InfoKey: Subject
+InfoValue: #{subject}
+    EOB
+    end
+    system(PDFTK_CMD, input_file, "update_info_utf8", meta_file, "output" ,output_file)
+  end
+end
+
+def main
+  usage if ARGV.size != 2
+
+  input_file = ARGV[0]
+  output_file = ARGV[1]
+
+  update_meta(input_file, output_file, title: "収支報告書", subject: "相原久美子")
+end
+
+main
+
+

--- a/meta_pdf/usage.sh
+++ b/meta_pdf/usage.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+curl http://www.soumu.go.jp/senkyo/seiji_s/seijishikin/contents/SS20191129/1000100017.pdf -O
+
+./meta_pdf.rb 1000100017.pdf output.pdf


### PR DESCRIPTION
PDFへのテキスト埋め込みですが、既存PDFに手を入れようとすると、pdftkを使うか、あるいはiTextライブラリ(Java or C#)を使うか、それとも商用ライブラリを使うかになると思います。これはPDFの解析が難しい（PDFツールによってPDFの生成方法がまちまちで、読み込み側はそれらを一通りサポートしないといけないので大変つらい）という理由によります。

その中では、Rubyで扱うんであればpdftkを使うのが手っ取り早いので、 #5 のような方法が一般的なのでは…と思います。

そんなわけで、趣旨とは異なるかもしれませんが、別解としてメタデータにテキストを埋め込む方法でサンプルを作ってみました（なお、こちらもpdftkを使っているので、別途インストールが必要です）。

使い方は `usage.sh` の通りで、これを実行すると指定された入力PDFのタイトルとサブジェクト（またはサブタイトル）にテキストを書き込んだ出力PDFを生成します。
メタデータをいじるだけなら外部gemライブラリやテキストフォントが特に不要なのは利点かもしれません。
